### PR TITLE
Implement notification id counter

### DIFF
--- a/durst/Cargo.toml
+++ b/durst/Cargo.toml
@@ -19,9 +19,7 @@ dbus = "0.8"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
+env_logger = "0.7"
 
 [build-dependencies]
 dbus-codegen = "0.5"
-
-[dev-dependencies]
-env_logger = "0.7"

--- a/durst/src/main.rs
+++ b/durst/src/main.rs
@@ -4,6 +4,7 @@ mod test;
 
 use dbus::arg;
 use dbus::blocking::LocalConnection;
+use dbus::blocking::stdintf::org_freedesktop_dbus::RequestNameReply;
 use dbus::tree;
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
@@ -84,7 +85,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut c = LocalConnection::new_session()?;
 
-    c.request_name("org.freedesktop.Notifications", false, true, true)?;
+    let r = c.request_name("org.freedesktop.Notifications", false, true, true)?;
+    if r != RequestNameReply::PrimaryOwner {
+        panic!("Another notification daemon is running!");
+    }
 
     let tree = factory
         .tree(())

--- a/durst/src/main.rs
+++ b/durst/src/main.rs
@@ -104,6 +104,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn main() {
+    // Temporary logging setup
+    env_logger::init();
     if let Err(e) = run() {
         println!("{}", e);
     }


### PR DESCRIPTION
A pretty small PR to start off with, I couldn't find any other way to enable debug logging when running the executable so to make things easier I moved `env_logger` to be a main dependency, at least until we're done with the initial stages of development.